### PR TITLE
chore: empty commit timestamp

### DIFF
--- a/.github/workflows/confluence.yaml
+++ b/.github/workflows/confluence.yaml
@@ -1,3 +1,4 @@
+# empty commit to force re-deployment = timestamp - 2026-06-09T19:47:39Z
 name: Sync Docs to Confluence
 
 on:


### PR DESCRIPTION
This PR contains a GPG-signed commit for commit signing verification.